### PR TITLE
Add pytest, pytest-asyncio, pytest-cov as dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,5 +102,12 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+    "pytest-cov>=7.0.0",
+]
+
 [project.scripts]
 onshape-mcp = "onshape_mcp.server:main"

--- a/uv.lock
+++ b/uv.lock
@@ -565,7 +565,7 @@ wheels = [
 
 [[package]]
 name = "onshape-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -593,6 +593,13 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.96.0" },
@@ -616,6 +623,13 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.23.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

- Adds `pytest`, `pytest-asyncio`, and `pytest-cov` to the `[dependency-groups] dev` section in `pyproject.toml`
- Updates `uv.lock` accordingly

## Why

The repo ships 698 tests but the test dependencies weren't declared in the project file, so `uv sync` alone wasn't enough to run them. This makes the test suite runnable out of the box with:

\`\`\`bash
uv sync
uv run python -m pytest tests/
\`\`\`

All 698 tests pass with no Onshape API credentials needed (fully mocked).

## Test plan

- [ ] `uv sync` installs pytest, pytest-asyncio, pytest-cov
- [ ] `uv run python -m pytest tests/` reports 698 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)