### PR TITLE
fix: add required endBound (BoundingType) param to extrude builder (fixes #8)

### DIFF
--- a/onshape_mcp/builders/extrude.py
+++ b/onshape_mcp/builders/extrude.py
@@ -155,6 +155,22 @@ class ExtrudeBuilder:
                         "libraryRelationType": "NONE",
                     },
                     {
+                        # Onshape's public extrude feature requires an endBound
+                        # (BoundingType) enum. SYMMETRIC is NOT a BoundingType
+                        # value -- it is the separate `symmetric` boolean below.
+                        # So endBound stays BLIND and `symmetric` toggles the
+                        # centered case. Omitting endBound entirely makes the
+                        # feature spec incomplete and current Onshape (FS 3008)
+                        # rejects the whole feature with HTTP 400. See issue #8.
+                        "btType": "BTMParameterEnum-145",
+                        "namespace": "",
+                        "enumName": "BoundingType",
+                        "value": "BLIND",
+                        "parameterId": "endBound",
+                        "parameterName": "",
+                        "libraryRelationType": "NONE",
+                    },
+                    {
                         "btType": "BTMParameterQuantity-147",
                         "isInteger": False,
                         "value": depth_value_m,

--- a/tests/builders/test_extrude.py
+++ b/tests/builders/test_extrude.py
@@ -210,9 +210,10 @@ class TestExtrudeBuilder:
     def test_end_type_defaults_to_blind(self):
         """symmetric boolean present and False by default for back-compat.
 
-        Onshape's public extrude feature rejects an `endBound` enum; it uses a
-        simple `symmetric: true/false` boolean. The builder translates our
-        ExtrudeEndType enum into that boolean so callers get a clean API.
+        Onshape's public extrude feature needs endBound=BLIND (a BoundingType)
+        AND a separate `symmetric: true/false` boolean (SYMMETRIC is not a
+        BoundingType value). The builder always emits endBound=BLIND and
+        translates our ExtrudeEndType enum into the symmetric boolean.
         """
         extrude = ExtrudeBuilder(sketch_feature_id="sketch1")
         result = extrude.build()
@@ -286,8 +287,11 @@ class TestExtrudeBuilder:
         assert result["feature"]["name"] == "CompleteExtrude"
 
         parameters = result["feature"]["parameters"]
-        # entities, operationType, endBound, depth, oppositeDirection
-        assert len(parameters) == 5
+        # entities, operationType, endBound, depth, oppositeDirection, symmetric
+        assert len(parameters) == 6
+        end_bound = next(p for p in parameters if p["parameterId"] == "endBound")
+        assert end_bound["enumName"] == "BoundingType"
+        assert end_bound["value"] == "BLIND"
 
     def test_zero_depth(self):
         """Test handling zero depth."""


### PR DESCRIPTION
## What

Adds the required `endBound` (`BoundingType`) enum parameter (value `BLIND`) to the extrude feature payload in `builders/extrude.py`, keeping the existing `symmetric` boolean.

## Why

`create_extrude` returns **HTTP 400** for any input in documents on the current FeatureScript standard library (**libraryVersion 3008**). `thicken` (which sends a complete param set) works in the same document, and the `write_featurescript_feature` escape hatch works too - so it is isolated to the extrude payload.

The extrude builder omitted `endBound`; the code comment shows it was removed after a live probe rejected `endBound: SYMMETRIC` ("does not match its feature spec"). But `SYMMETRIC` is not a `BoundingType` value - it is the separate `symmetric` boolean. Onshape's `extrude` uses `endBound: BLIND` **together with** `symmetric: true/false`. Removing `endBound` entirely left the feature spec incomplete, which 3008 now rejects.

Fixes #8.

## Change

- `builders/extrude.py`: emit `endBound = BLIND` (`BoundingType`) alongside the existing `symmetric` boolean.
- `tests/builders/test_extrude.py`: assert `endBound` present (`BoundingType`/`BLIND`); param count 5 -> 6; corrected a now-stale docstring.

## Test plan

- **Unit:** builder now emits `[entities, operationType, endBound, depth, oppositeDirection, symmetric]` with `endBound` enumName `BoundingType`, value `BLIND`. Verified by direct import of the builder.
- **Live (please confirm):** I could not verify the running MCP server against Onshape from my environment (needs an MCP/session restart). Please confirm `create_extrude` (both BLIND and SYMMETRIC) against a 3008 document before merge.
- **`fillet`** almost certainly needs the analogous fix (see issue #8); left out here to keep this PR focused on extrude.
