### PR TITLE
Fix native Boolean payload for current Onshape

### DIFF
--- a/onshape_mcp/builders/boolean.py
+++ b/onshape_mcp/builders/boolean.py
@@ -8,8 +8,8 @@ class BooleanType(Enum):
     """Boolean operation type."""
 
     UNION = "UNION"
-    SUBTRACT = "SUBTRACT"
-    INTERSECT = "INTERSECT"
+    SUBTRACT = "SUBTRACTION"
+    INTERSECT = "INTERSECTION"
 
 
 class BooleanBuilder:
@@ -76,9 +76,16 @@ class BooleanBuilder:
         if self.boolean_type in (BooleanType.SUBTRACT, BooleanType.INTERSECT):
             if not self.target_body_queries:
                 raise ValueError(
-                    f"At least one target body must be added for {self.boolean_type.value} "
+                    f"At least one target body must be added for {self.boolean_type.name} "
                     "operations"
                 )
+
+        selected_tools = list(self.tool_body_queries)
+        if self.boolean_type in (BooleanType.UNION, BooleanType.INTERSECT):
+            # Native booleanBodies uses one `tools` query for every body in
+            # union/intersection. The separate `targets` query is visible only
+            # for subtraction in the current feature specification.
+            selected_tools.extend(self.target_body_queries)
 
         parameters: List[Dict[str, Any]] = [
             {
@@ -86,25 +93,23 @@ class BooleanBuilder:
                 "namespace": "",
                 "enumName": "BooleanOperationType",
                 "value": self.boolean_type.value,
-                "parameterId": "booleanOperationType",
+                "parameterId": "operationType",
                 "parameterName": "",
-                "libraryRelationType": "NONE",
             },
             {
                 "btType": "BTMParameterQueryList-148",
                 "queries": [
                     {
                         "btType": "BTMIndividualQuery-138",
-                        "deterministicIds": self.tool_body_queries,
+                        "deterministicIds": selected_tools,
                     }
                 ],
                 "parameterId": "tools",
                 "parameterName": "",
-                "libraryRelationType": "NONE",
             },
         ]
 
-        if self.target_body_queries:
+        if self.boolean_type == BooleanType.SUBTRACT:
             parameters.append(
                 {
                     "btType": "BTMParameterQueryList-148",
@@ -116,7 +121,6 @@ class BooleanBuilder:
                     ],
                     "parameterId": "targets",
                     "parameterName": "",
-                    "libraryRelationType": "NONE",
                 }
             )
 
@@ -124,7 +128,7 @@ class BooleanBuilder:
             "btType": "BTFeatureDefinitionCall-1406",
             "feature": {
                 "btType": "BTMFeature-134",
-                "featureType": "boolean",
+                "featureType": "booleanBodies",
                 "name": self.name,
                 "suppressed": False,
                 "namespace": "",

--- a/tests/builders/test_boolean.py
+++ b/tests/builders/test_boolean.py
@@ -10,8 +10,8 @@ class TestBooleanType:
 
     def test_boolean_type_values(self):
         assert BooleanType.UNION.value == "UNION"
-        assert BooleanType.SUBTRACT.value == "SUBTRACT"
-        assert BooleanType.INTERSECT.value == "INTERSECT"
+        assert BooleanType.SUBTRACT.value == "SUBTRACTION"
+        assert BooleanType.INTERSECT.value == "INTERSECTION"
 
 
 class TestBooleanBuilder:
@@ -77,7 +77,7 @@ class TestBooleanBuilder:
         assert result["btType"] == "BTFeatureDefinitionCall-1406"
         feature = result["feature"]
         assert feature["btType"] == "BTMFeature-134"
-        assert feature["featureType"] == "boolean"
+        assert feature["featureType"] == "booleanBodies"
         assert feature["name"] == "TestBool"
 
     def test_build_boolean_type_parameter(self):
@@ -89,9 +89,10 @@ class TestBooleanBuilder:
             result = b.build()
             params = result["feature"]["parameters"]
             type_param = next(
-                p for p in params if p["parameterId"] == "booleanOperationType"
+                p for p in params if p["parameterId"] == "operationType"
             )
             assert type_param["value"] == bt.value
+            assert type_param["enumName"] == "BooleanOperationType"
 
     def test_build_tools_parameter(self):
         b = BooleanBuilder()
@@ -129,7 +130,22 @@ class TestBooleanBuilder:
         params = result["feature"]["parameters"]
 
         target_params = [p for p in params if p["parameterId"] == "targets"]
-        assert len(target_params) == 1
+        tools = next(p for p in params if p["parameterId"] == "tools")
+        assert target_params == []
+        assert tools["queries"][0]["deterministicIds"] == ["tool1", "tgt1"]
+
+    def test_build_intersection_combines_all_bodies_in_tools(self):
+        b = BooleanBuilder(boolean_type=BooleanType.INTERSECT)
+        b.add_tool_body("tool1").add_target_body("target1")
+        params = b.build()["feature"]["parameters"]
+
+        by_id = {parameter["parameterId"]: parameter for parameter in params}
+        assert by_id["operationType"]["value"] == "INTERSECTION"
+        assert by_id["tools"]["queries"][0]["deterministicIds"] == [
+            "tool1",
+            "target1",
+        ]
+        assert "targets" not in by_id
 
     def test_method_chaining(self):
         b = (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1939,7 +1939,7 @@ class TestFeatureTools:
     @patch("onshape_mcp.server.apply_feature_and_check")
     async def test_create_boolean_success(self, mock_apply):
         mock_apply.return_value = _mock_apply_result(
-            feature_id="bool123", feature_type="boolean"
+            feature_id="bool123", feature_type="booleanBodies"
         )
         result = await call_tool("create_boolean", {
             "documentId": "d", "workspaceId": "w", "elementId": "e",
@@ -1948,6 +1948,13 @@ class TestFeatureTools:
         import json as _json
         parsed = _json.loads(result[0].text)
         assert parsed["ok"] is True and parsed["feature_id"] == "bool123"
+        payload = mock_apply.await_args.args[4]
+        feature = payload["feature"]
+        params = {parameter["parameterId"]: parameter for parameter in feature["parameters"]}
+        assert feature["featureType"] == "booleanBodies"
+        assert params["operationType"]["value"] == "UNION"
+        assert params["tools"]["queries"][0]["deterministicIds"] == ["b1", "b2"]
+        assert "libraryRelationType" not in str(payload)
 
     @pytest.mark.asyncio
     @patch("onshape_mcp.server.apply_feature_and_check")


### PR DESCRIPTION
## Summary

- emit the current native Boolean feature type (`booleanBodies`)
- use the current `operationType` parameter and `UNION` / `SUBTRACTION` / `INTERSECTION` enum values
- serialize union and intersection bodies together in `tools`, while reserving `targets` for subtraction
- omit the rejected `libraryRelationType: NONE` field from Boolean parameters
- add exact builder and mocked server payload assertions

## Root cause

Current Onshape feature specifications expose native Boolean as `booleanBodies`, with parameter `operationType`. The existing builder emits the stale feature type `boolean`, the stale parameter ID `booleanOperationType`, and stale values `SUBTRACT` / `INTERSECT`. On current Onshape this returns HTTP 400 with the sanitized diagnostic `Feature has invalid type`.

The three `libraryRelationType` removals in this builder match and credit #7. They are included here because current Onshape rejects that field before it can evaluate the corrected Boolean schema. This PR addresses the separately confirmed Boolean defect and is not intended to replace the broader builder cleanup in #7.

## Sanitized live verification

Tested against a newly created disposable document using the current live feature specification (library version 3029). No existing models were touched, and every disposable document was deleted afterward.

| Operation | Emitted structure | Result |
| --- | --- | --- |
| Union | `operationType=UNION`, `tools` | `featureStatus=OK` |
| Subtraction | `operationType=SUBTRACTION`, `tools`, `targets` | `featureStatus=OK` |
| Intersection | `operationType=INTERSECTION`, `tools` | `featureStatus=OK` |

All three payloads omit `libraryRelationType`. The resulting native features regenerated successfully and remained native/editable feature-tree operations.

## Validation

- `uv run --frozen ruff check --no-cache onshape_mcp/builders/boolean.py tests/builders/test_boolean.py tests/test_server.py`
- focused tests: 168 passed
- full suite: 699 passed, 3 pre-existing Pydantic deprecation warnings, 53.19% coverage
- `onshape_mcp/builders/boolean.py`: 100% test coverage

Related to #8. This focused change does not claim to resolve every defect reported there; #7 remains the relevant broad fix for rejected parameter fields in the other native builders.
