### PR TITLE
Fix feature builders against current Onshape API (libraryRelationType 400 + linear feature pattern params)

### DIFF
--- a/onshape_mcp/builders/boolean.py
+++ b/onshape_mcp/builders/boolean.py
@@ -88,7 +88,6 @@ class BooleanBuilder:
                 "value": self.boolean_type.value,
                 "parameterId": "booleanOperationType",
                 "parameterName": "",
-                "libraryRelationType": "NONE",
             },
             {
                 "btType": "BTMParameterQueryList-148",
@@ -100,7 +99,6 @@ class BooleanBuilder:
                 ],
                 "parameterId": "tools",
                 "parameterName": "",
-                "libraryRelationType": "NONE",
             },
         ]
 
@@ -116,7 +114,6 @@ class BooleanBuilder:
                     ],
                     "parameterId": "targets",
                     "parameterName": "",
-                    "libraryRelationType": "NONE",
                 }
             )
 

--- a/onshape_mcp/builders/chamfer.py
+++ b/onshape_mcp/builders/chamfer.py
@@ -106,7 +106,6 @@ class ChamferBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterEnum-145",
@@ -115,7 +114,6 @@ class ChamferBuilder:
                         "value": self.chamfer_type.value,
                         "parameterId": "chamferType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -125,7 +123,6 @@ class ChamferBuilder:
                         "expression": distance_expression,
                         "parameterId": "width",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/extrude.py
+++ b/onshape_mcp/builders/extrude.py
@@ -143,7 +143,6 @@ class ExtrudeBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterEnum-145",
@@ -152,7 +151,6 @@ class ExtrudeBuilder:
                         "value": self.operation_type.value,
                         "parameterId": "operationType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -162,21 +160,18 @@ class ExtrudeBuilder:
                         "expression": depth_expression,
                         "parameterId": "depth",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterBoolean-144",
                         "value": self.opposite_direction,
                         "parameterId": "oppositeDirection",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterBoolean-144",
                         "value": self.end_type == ExtrudeEndType.SYMMETRIC,
                         "parameterId": "symmetric",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/fillet.py
+++ b/onshape_mcp/builders/fillet.py
@@ -95,7 +95,6 @@ class FilletBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -105,7 +104,6 @@ class FilletBuilder:
                         "expression": radius_expression,
                         "parameterId": "radius",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/offset_plane.py
+++ b/onshape_mcp/builders/offset_plane.py
@@ -83,7 +83,6 @@ class OffsetPlaneBuilder:
                         "value": "OFFSET",
                         "parameterId": "cplaneType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQueryList-148",
@@ -95,7 +94,6 @@ class OffsetPlaneBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -105,14 +103,12 @@ class OffsetPlaneBuilder:
                         "expression": offset_expression,
                         "parameterId": "offset",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterBoolean-144",
                         "value": self.flip,
                         "parameterId": "oppositeDirection",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/pattern.py
+++ b/onshape_mcp/builders/pattern.py
@@ -136,7 +136,7 @@ class LinearPatternBuilder:
                     "queryString": "",
                 }
             ],
-            "parameterId": "directionQuery",
+            "parameterId": "directionOne",
             "parameterName": "",
         }
 
@@ -170,14 +170,9 @@ class LinearPatternBuilder:
                 "namespace": "",
                 "parameters": [
                     {
-                        "btType": "BTMParameterQueryList-148",
-                        "queries": [
-                            {
-                                "btType": "BTMIndividualQuery-138",
-                                "deterministicIds": self.feature_queries,
-                            }
-                        ],
-                        "parameterId": "entities",
+                        "btType": "BTMParameterFeatureList-1749",
+                        "featureIds": self.feature_queries,
+                        "parameterId": "instanceFunction",
                         "parameterName": "",
                     },
                     self._build_direction_query(),

--- a/onshape_mcp/builders/pattern.py
+++ b/onshape_mcp/builders/pattern.py
@@ -138,7 +138,6 @@ class LinearPatternBuilder:
             ],
             "parameterId": "directionQuery",
             "parameterName": "",
-            "libraryRelationType": "NONE",
         }
 
     def build(self) -> Dict[str, Any]:
@@ -180,7 +179,6 @@ class LinearPatternBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     self._build_direction_query(),
                     {
@@ -190,7 +188,6 @@ class LinearPatternBuilder:
                         "value": PatternType.FEATURE.value,
                         "parameterId": "patternType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -200,7 +197,6 @@ class LinearPatternBuilder:
                         "expression": distance_expression,
                         "parameterId": "distance",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -210,7 +206,6 @@ class LinearPatternBuilder:
                         "expression": str(self.count),
                         "parameterId": "instanceCount",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },
@@ -313,7 +308,6 @@ class CircularPatternBuilder:
             ],
             "parameterId": "axisQuery",
             "parameterName": "",
-            "libraryRelationType": "NONE",
         }
 
     def build(self) -> Dict[str, Any]:
@@ -351,7 +345,6 @@ class CircularPatternBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     self._build_axis_query(),
                     {
@@ -361,7 +354,6 @@ class CircularPatternBuilder:
                         "value": PatternType.FEATURE.value,
                         "parameterId": "patternType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -371,7 +363,6 @@ class CircularPatternBuilder:
                         "expression": angle_expression,
                         "parameterId": "angle",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -381,7 +372,6 @@ class CircularPatternBuilder:
                         "expression": str(self.count),
                         "parameterId": "instanceCount",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/revolve.py
+++ b/onshape_mcp/builders/revolve.py
@@ -116,7 +116,6 @@ class RevolveBuilder:
             ],
             "parameterId": "axis",
             "parameterName": "",
-            "libraryRelationType": "NONE",
         }
 
     def build(self) -> Dict[str, Any]:
@@ -161,7 +160,6 @@ class RevolveBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     self._build_axis_query(),
                     {
@@ -171,7 +169,6 @@ class RevolveBuilder:
                         "value": self.operation_type.value,
                         "parameterId": "operationType",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -181,14 +178,12 @@ class RevolveBuilder:
                         "expression": angle_expression,
                         "parameterId": "revolveAngle",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterBoolean-144",
                         "value": self.opposite_direction,
                         "parameterId": "oppositeDirection",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/shell.py
+++ b/onshape_mcp/builders/shell.py
@@ -101,7 +101,6 @@ class ShellBuilder:
                         ],
                         "parameterId": "entities",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterQuantity-147",
@@ -111,14 +110,12 @@ class ShellBuilder:
                         "expression": thickness_expression,
                         "parameterId": "thickness",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                     {
                         "btType": "BTMParameterBoolean-144",
                         "value": self.outward,
                         "parameterId": "oppositeDirection",
                         "parameterName": "",
-                        "libraryRelationType": "NONE",
                     },
                 ],
             },

--- a/onshape_mcp/builders/sketch_constraints.py
+++ b/onshape_mcp/builders/sketch_constraints.py
@@ -62,7 +62,6 @@ def _ref_param(parameter_id: str, entity_ref: str) -> Dict[str, Any]:
         "value": entity_ref,
         "parameterId": parameter_id,
         "parameterName": "",
-        "libraryRelationType": "NONE",
     }
 
 
@@ -80,7 +79,6 @@ def _quantity_param(parameter_id: str, expression: str) -> Dict[str, Any]:
         "expression": expression,
         "parameterId": parameter_id,
         "parameterName": "",
-        "libraryRelationType": "NONE",
     }
 
 
@@ -92,7 +90,6 @@ def _enum_param(parameter_id: str, enum_name: str, value: str) -> Dict[str, Any]
         "value": value,
         "parameterId": parameter_id,
         "parameterName": "",
-        "libraryRelationType": "NONE",
     }
 
 

--- a/tests/builders/test_pattern.py
+++ b/tests/builders/test_pattern.py
@@ -87,15 +87,16 @@ class TestLinearPatternBuilder:
         result = lp.build()
         params = result["feature"]["parameters"]
 
-        entities = next(p for p in params if p["parameterId"] == "entities")
-        assert entities["queries"][0]["deterministicIds"] == ["f1", "f2"]
+        inst = next(p for p in params if p["parameterId"] == "instanceFunction")
+        assert inst["btType"] == "BTMParameterFeatureList-1749"
+        assert inst["featureIds"] == ["f1", "f2"]
 
     def test_build_direction_uses_edge_id(self):
         lp = LinearPatternBuilder(direction_edge_id="JHl")
         lp.add_feature("f1")
         result = lp.build()
         params = result["feature"]["parameters"]
-        dir_param = next(p for p in params if p["parameterId"] == "directionQuery")
+        dir_param = next(p for p in params if p["parameterId"] == "directionOne")
         assert dir_param["queries"][0]["deterministicIds"] == ["JHl"]
 
     def test_build_without_direction_edge_raises(self):
@@ -109,7 +110,7 @@ class TestLinearPatternBuilder:
         lp.add_feature("f1").set_direction_edge("JHl")
         result = lp.build()
         params = result["feature"]["parameters"]
-        dir_param = next(p for p in params if p["parameterId"] == "directionQuery")
+        dir_param = next(p for p in params if p["parameterId"] == "directionOne")
         assert dir_param["queries"][0]["deterministicIds"] == ["JHl"]
 
     def test_build_distance_without_variable(self):


### PR DESCRIPTION
Fixes #13

Two commits:

1. **Drop `libraryRelationType` from all builder payloads** — Onshape now rejects `"libraryRelationType": "NONE"` with HTTP 400 (BTWeirdStringValueException). The field arrived with the initial vendor import, hard-coded to NONE; the server generates `DEFAULT` on its own when the field is omitted. 38 lines removed across 9 builders.

2. **Fix linear FEATURE pattern parameters** — features belong in `instanceFunction` (BTMParameterFeatureList-1749) rather than deterministicIds inside `entities`, and the direction parameter id is `directionOne` per the std spec (was `directionQuery`). Tests updated accordingly.

Validation: builders test suite 317 passed · in production against cad.onshape.com (2026-07-23): ~75 successful feature POSTs with the field stripped (extrudes, fillets, booleans, transforms, inline variable expressions), and a 7-instance feature pattern regenerating OK first try with the corrected parameters. The circular pattern builder is untouched — it likely shares the direction-param issue but was not validated in production.

Details in the linked issue.

— TechSprint
