### PR TITLE
Add rename_document, rename_element, rename_feature tools + fix concurrent-write race

### DIFF
--- a/onshape_mcp/api/documents.py
+++ b/onshape_mcp/api/documents.py
@@ -311,6 +311,93 @@ class DocumentManager:
             thumbnail=thumbnail_url,
         )
 
+    async def rename_document(self, document_id: str, new_name: str) -> DocumentInfo:
+        """Rename an existing document.
+
+        Args:
+            document_id: Document ID
+            new_name: New name for the document
+
+        Returns:
+            Updated DocumentInfo
+        """
+        response = await self.client.post(
+            f"/api/v10/documents/{document_id}", data={"name": new_name}
+        )
+
+        thumbnail_data = response.get("thumbnail")
+        thumbnail_url = None
+        if thumbnail_data and isinstance(thumbnail_data, dict):
+            thumbnail_url = thumbnail_data.get("href")
+
+        return DocumentInfo(
+            id=response.get("id", document_id),
+            name=response.get("name", new_name),
+            createdAt=response.get("createdAt"),
+            modifiedAt=response.get("modifiedAt"),
+            ownerId=response.get("owner", {}).get("id", ""),
+            ownerName=response.get("owner", {}).get("name"),
+            public=response.get("public", False),
+            description=response.get("description"),
+            thumbnail=thumbnail_url,
+        )
+
+    async def rename_element(
+        self, document_id: str, workspace_id: str, element_id: str, new_name: str
+    ) -> str:
+        """Rename an element (Part Studio, Assembly, drawing, etc.) — i.e. a document tab.
+
+        Onshape has no dedicated "rename tab" endpoint; the name lives as a
+        property on the element's Metadata resource. We GET the current
+        metadata, find the property whose schema `name` is "Name" (rather than
+        trusting a hardcoded propertyId, which is a metadata-schema-version
+        detail we shouldn't assume is stable), then POST just that property
+        back.
+
+        Args:
+            document_id: Document ID
+            workspace_id: Workspace ID
+            element_id: Element ID to rename
+            new_name: New display name for the element
+
+        Returns:
+            The new name, as confirmed by Onshape's response.
+
+        Raises:
+            ValueError: if the metadata response has no "Name" property
+                (unexpected shape — surfaced so the caller can inspect it
+                rather than silently no-op renaming).
+        """
+        metadata_path = f"/api/metadata/d/{document_id}/w/{workspace_id}/e/{element_id}"
+        current = await self.client.get(metadata_path)
+
+        properties = current.get("properties") or []
+        name_property_id: Optional[str] = None
+        for prop in properties:
+            if not isinstance(prop, dict):
+                continue
+            if str(prop.get("name", "")).strip().lower() == "name":
+                name_property_id = prop.get("propertyId")
+                break
+
+        if not name_property_id:
+            raise ValueError(
+                "Could not find a 'Name' property in element metadata; "
+                f"available properties: {[p.get('name') for p in properties if isinstance(p, dict)]}"
+            )
+
+        response = await self.client.post(
+            metadata_path,
+            data={"properties": [{"propertyId": name_property_id, "value": new_name}]},
+        )
+
+        updated_properties = response.get("properties") or []
+        for prop in updated_properties:
+            if isinstance(prop, dict) and prop.get("propertyId") == name_property_id:
+                return prop.get("value", new_name)
+
+        return new_name
+
     async def delete_document(self, document_id: str) -> Dict[str, Any]:
         """Delete (trash) a document.
 

--- a/onshape_mcp/api/feature_apply.py
+++ b/onshape_mcp/api/feature_apply.py
@@ -9,12 +9,24 @@ Routing every feature mutation through `apply_feature_and_check` gives callers
 Evidence for the response shape used here is captured in
 `scratchpad/smoke-test.md` and `scratchpad/probe-patch-and-shadedviews.md`
 in the parent project (`/Users/shef/projects/onshape-mcp/`).
+
+Also serializes the mutating POST per (document, workspace, element) — see
+`_get_element_lock`. Onshape's feature-tree endpoint applies each write
+against a base microversion and regenerates downstream features from there;
+firing concurrent mutating calls at the same Part Studio (e.g. a batch of
+parallel renames) lets them race on that base and corrupts the tree even
+though each individual call is a no-op on geometry. Confirmed live: 20
+parallel `rename_feature` calls against one Part Studio put 21 of 23
+features into ERROR/WARNING and visibly collapsed the model (recovered via
+Onshape's version history). Reads aren't locked, only the write.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
-from typing import Any, Dict, List, Literal, Optional
+from collections import defaultdict
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -23,6 +35,19 @@ from .client import OnshapeClient
 
 
 FeatureStatus = Literal["OK", "INFO", "WARNING", "ERROR", "UNKNOWN"]
+
+# One lock per (document_id, workspace_id, element_id), created lazily.
+# defaultdict's __getitem__ is a single synchronous dict op with no `await`
+# inside, so it's safe to call from multiple concurrent asyncio tasks without
+# its own lock — no two tasks can interleave mid-lookup on one event loop.
+_element_locks: "defaultdict[Tuple[str, str, str], asyncio.Lock]" = defaultdict(
+    asyncio.Lock
+)
+
+
+def _get_element_lock(document_id: str, workspace_id: str, element_id: str) -> asyncio.Lock:
+    """Return the lock guarding mutating writes to this Part Studio/Assembly."""
+    return _element_locks[(document_id, workspace_id, element_id)]
 
 
 class FeatureApplyResult(BaseModel):
@@ -111,7 +136,8 @@ async def apply_feature_and_check(
             logger.warning(f"track_changes: before-snapshot failed ({e}); skipping diff")
             bodies_before = None
 
-    response = await client.post(path, data=feature_payload)
+    async with _get_element_lock(document_id, workspace_id, element_id):
+        response = await client.post(path, data=feature_payload)
 
     # Primary source: top-level featureState in the POST response.
     state = response.get("featureState") if isinstance(response, dict) else None
@@ -220,7 +246,8 @@ async def apply_assembly_feature_and_check(
     )
     path = base if operation == "create" else f"{base}/featureid/{feature_id}"
 
-    response = await client.post(path, data=feature_payload)
+    async with _get_element_lock(document_id, workspace_id, element_id):
+        response = await client.post(path, data=feature_payload)
 
     state = response.get("featureState") if isinstance(response, dict) else None
     feature = response.get("feature", {}) if isinstance(response, dict) else {}

--- a/onshape_mcp/api/feature_apply.py
+++ b/onshape_mcp/api/feature_apply.py
@@ -382,6 +382,68 @@ async def update_feature_params_and_check(
     )
 
 
+async def rename_feature_and_check(
+    client: OnshapeClient,
+    document_id: str,
+    workspace_id: str,
+    element_id: str,
+    feature_id: str,
+    new_name: str,
+) -> FeatureApplyResult:
+    """Rename a Part Studio feature (the label in the feature tree, e.g.
+    'Extrude 1' -> 'Boss extrude').
+
+    Same re-POST-the-whole-feature mechanism as
+    `update_feature_params_and_check`, except it patches the feature's
+    top-level `name` field instead of an entry in `parameters`.
+
+    Args:
+        client: Active OnshapeClient.
+        document_id, workspace_id, element_id: Usual triple.
+        feature_id: Feature to rename.
+        new_name: New display name.
+
+    Returns:
+        FeatureApplyResult with the post-rename featureStatus (renaming
+        doesn't change geometry, so this should always be OK/INFO unless the
+        feature was already broken).
+
+    Raises:
+        ValueError: feature_id not found in the element.
+    """
+    if not feature_id:
+        raise ValueError("feature_id is required")
+
+    base = (
+        f"/api/v9/partstudios/d/{document_id}/w/{workspace_id}/e/{element_id}/features"
+    )
+    features_doc = await client.get(base)
+    features: List[Dict[str, Any]] = features_doc.get("features", []) or []
+
+    target: Optional[Dict[str, Any]] = None
+    for feat in features:
+        if feat.get("featureId") == feature_id:
+            target = feat
+            break
+    if target is None:
+        raise ValueError(
+            f"feature_id {feature_id!r} not found in element. "
+            f"Available ids: {[f.get('featureId') for f in features]}"
+        )
+
+    target["name"] = new_name
+
+    return await apply_feature_and_check(
+        client,
+        document_id,
+        workspace_id,
+        element_id,
+        {"feature": target},
+        operation="update",
+        feature_id=feature_id,
+    )
+
+
 def _extract_error_message(
     state: Dict[str, Any],
     fs_status: Optional[Dict[str, Any]] = None,

--- a/onshape_mcp/server.py
+++ b/onshape_mcp/server.py
@@ -5,7 +5,7 @@ import sys
 import asyncio
 import base64
 import json
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 import httpx
 from dotenv import load_dotenv
 from mcp.server import Server
@@ -34,6 +34,7 @@ from .api.feature_apply import (
     apply_feature_and_check,
     apply_assembly_feature_and_check,
     update_feature_params_and_check,
+    rename_feature_and_check,
     FeatureApplyResult,
 )
 from .api.entities import EntityManager
@@ -567,6 +568,26 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="rename_feature",
+            description=(
+                "Rename a feature in the feature tree (e.g. 'Extrude 1' -> "
+                "'Boss extrude'). Purely a label change — geometry is "
+                "untouched. Returns the standard {ok, status, feature_id, "
+                "feature_name, ...} contract."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "documentId": {"type": "string", "description": "Document ID"},
+                    "workspaceId": {"type": "string", "description": "Workspace ID"},
+                    "elementId": {"type": "string", "description": "Part Studio element ID"},
+                    "featureId": {"type": "string", "description": "ID of the feature to rename"},
+                    "newName": {"type": "string", "description": "New display name for the feature"},
+                },
+                "required": ["documentId", "workspaceId", "elementId", "featureId", "newName"],
+            },
+        ),
+        Tool(
             name="list_documents",
             description="List documents in your Onshape account with optional filtering and sorting",
             inputSchema={
@@ -731,6 +752,35 @@ async def list_tools() -> list[Tool]:
                     "documentId": {"type": "string", "description": "Document ID to delete"},
                 },
                 "required": ["documentId"],
+            },
+        ),
+        Tool(
+            name="rename_document",
+            description="Rename an existing Onshape document. Returns {ok, document_id, document_name}.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "documentId": {"type": "string", "description": "Document ID to rename"},
+                    "newName": {"type": "string", "description": "New name for the document"},
+                },
+                "required": ["documentId", "newName"],
+            },
+        ),
+        Tool(
+            name="rename_element",
+            description=(
+                "Rename an element (a document tab — Part Studio, Assembly, "
+                "drawing, etc.). Returns {ok, element_id, element_name}."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "documentId": {"type": "string", "description": "Document ID"},
+                    "workspaceId": {"type": "string", "description": "Workspace ID"},
+                    "elementId": {"type": "string", "description": "Element ID to rename"},
+                    "newName": {"type": "string", "description": "New display name for the element"},
+                },
+                "required": ["documentId", "workspaceId", "elementId", "newName"],
             },
         ),
         Tool(
@@ -3228,6 +3278,23 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent | ImageConten
             logger.exception("Unexpected error updating feature")
             return [TextContent(type="text", text=_exception_json(e, tool_name=name))]
 
+    elif name == "rename_feature":
+        try:
+            result = await rename_feature_and_check(
+                client,
+                arguments["documentId"],
+                arguments["workspaceId"],
+                arguments["elementId"],
+                arguments["featureId"],
+                arguments["newName"],
+            )
+            return [TextContent(type="text", text=_feature_apply_json(result, tool_name=name))]
+        except httpx.HTTPStatusError as e:
+            return [TextContent(type="text", text=_exception_json(e, tool_name=name, status_code=e.response.status_code))]
+        except Exception as e:
+            logger.exception("Unexpected error renaming feature")
+            return [TextContent(type="text", text=_exception_json(e, tool_name=name))]
+
     elif name == "list_documents":
         try:
             # Map filter type to API value
@@ -3676,6 +3743,73 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent | ImageConten
                 "ok": False,
                 "status": "EXCEPTION",
                 "document_id": arguments["documentId"],
+                "error_message": str(e),
+                "tool": name,
+            }, indent=2))]
+
+    elif name == "rename_document":
+        try:
+            doc = await document_manager.rename_document(
+                arguments["documentId"], arguments["newName"]
+            )
+            payload = {
+                "ok": True,
+                "status": "OK",
+                "document_id": doc.id,
+                "document_name": doc.name,
+                "error_message": None,
+                "tool": name,
+            }
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+        except httpx.HTTPStatusError as e:
+            return [TextContent(type="text", text=json.dumps({
+                "ok": False,
+                "status": "EXCEPTION",
+                "document_id": arguments["documentId"],
+                "error_message": f"HTTP {e.response.status_code}: {e}",
+                "tool": name,
+            }, indent=2))]
+        except Exception as e:
+            logger.exception("Unexpected error renaming document")
+            return [TextContent(type="text", text=json.dumps({
+                "ok": False,
+                "status": "EXCEPTION",
+                "document_id": arguments["documentId"],
+                "error_message": str(e),
+                "tool": name,
+            }, indent=2))]
+
+    elif name == "rename_element":
+        try:
+            new_name = await document_manager.rename_element(
+                arguments["documentId"],
+                arguments["workspaceId"],
+                arguments["elementId"],
+                arguments["newName"],
+            )
+            payload = {
+                "ok": True,
+                "status": "OK",
+                "element_id": arguments["elementId"],
+                "element_name": new_name,
+                "error_message": None,
+                "tool": name,
+            }
+            return [TextContent(type="text", text=json.dumps(payload, indent=2))]
+        except httpx.HTTPStatusError as e:
+            return [TextContent(type="text", text=json.dumps({
+                "ok": False,
+                "status": "EXCEPTION",
+                "element_id": arguments["elementId"],
+                "error_message": f"HTTP {e.response.status_code}: {e}",
+                "tool": name,
+            }, indent=2))]
+        except Exception as e:
+            logger.exception("Unexpected error renaming element")
+            return [TextContent(type="text", text=json.dumps({
+                "ok": False,
+                "status": "EXCEPTION",
+                "element_id": arguments["elementId"],
                 "error_message": str(e),
                 "tool": name,
             }, indent=2))]

--- a/tests/api/test_documents.py
+++ b/tests/api/test_documents.py
@@ -518,3 +518,86 @@ class TestDocumentManager:
         with pytest.raises(Exception) as exc_info:
             await document_manager.delete_document("doc_abc")
         assert "Forbidden" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_rename_document_success(self, document_manager, onshape_client):
+        """rename_document should POST /api/v10/documents/{did} with {"name": ...}."""
+        rename_response = {
+            "id": "doc_abc",
+            "name": "Renamed Document",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "modifiedAt": "2024-01-02T00:00:00Z",
+            "owner": {"id": "user1", "name": "Test User"},
+            "public": False,
+            "description": None,
+        }
+        onshape_client.post = AsyncMock(return_value=rename_response)
+
+        doc = await document_manager.rename_document("doc_abc", "Renamed Document")
+
+        assert isinstance(doc, DocumentInfo)
+        assert doc.id == "doc_abc"
+        assert doc.name == "Renamed Document"
+
+        onshape_client.post.assert_awaited_once()
+        path, kwargs = onshape_client.post.await_args[0], onshape_client.post.await_args[1]
+        assert path[0] == "/api/v10/documents/doc_abc"
+        assert kwargs["data"] == {"name": "Renamed Document"}
+
+    @pytest.mark.asyncio
+    async def test_rename_document_propagates_errors(self, document_manager, onshape_client):
+        onshape_client.post = AsyncMock(side_effect=Exception("404 Not Found"))
+        with pytest.raises(Exception) as exc_info:
+            await document_manager.rename_document("doc_missing", "New Name")
+        assert "Not Found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_rename_element_success(self, document_manager, onshape_client):
+        """rename_element should discover the 'Name' propertyId from a GET,
+        then POST only that property back to the same metadata path."""
+        metadata_response = {
+            "properties": [
+                {"propertyId": "prop_id_1", "name": "State", "value": "IN_PROGRESS"},
+                {"propertyId": "prop_id_2", "name": "Name", "value": "Part Studio 1"},
+            ]
+        }
+        update_response = {
+            "properties": [
+                {"propertyId": "prop_id_1", "name": "State", "value": "IN_PROGRESS"},
+                {"propertyId": "prop_id_2", "name": "Name", "value": "Bracket"},
+            ]
+        }
+        onshape_client.get = AsyncMock(return_value=metadata_response)
+        onshape_client.post = AsyncMock(return_value=update_response)
+
+        new_name = await document_manager.rename_element("doc1", "ws1", "el1", "Bracket")
+
+        assert new_name == "Bracket"
+
+        expected_path = "/api/metadata/d/doc1/w/ws1/e/el1"
+        onshape_client.get.assert_awaited_once_with(expected_path)
+        onshape_client.post.assert_awaited_once_with(
+            expected_path,
+            data={"properties": [{"propertyId": "prop_id_2", "value": "Bracket"}]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_rename_element_missing_name_property_raises(
+        self, document_manager, onshape_client
+    ):
+        """If metadata has no 'Name' property, raise instead of silently no-op'ing."""
+        onshape_client.get = AsyncMock(
+            return_value={"properties": [{"propertyId": "prop_id_1", "name": "State"}]}
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await document_manager.rename_element("doc1", "ws1", "el1", "Bracket")
+
+        assert "Name" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_rename_element_propagates_errors(self, document_manager, onshape_client):
+        onshape_client.get = AsyncMock(side_effect=Exception("500 Server Error"))
+        with pytest.raises(Exception) as exc_info:
+            await document_manager.rename_element("doc1", "ws1", "el1", "Bracket")
+        assert "Server Error" in str(exc_info.value)

--- a/tests/api/test_feature_apply.py
+++ b/tests/api/test_feature_apply.py
@@ -12,6 +12,7 @@ import pytest
 from onshape_mcp.api.feature_apply import (
     apply_assembly_feature_and_check,
     update_feature_params_and_check,
+    rename_feature_and_check,
     FeatureApplyResult,
 )
 
@@ -277,3 +278,70 @@ async def test_update_reports_post_error_status(onshape_client):
     assert result.ok is False
     assert result.status == "ERROR"
     assert "positive" in (result.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_rename_feature_patches_name_and_reposts(onshape_client):
+    """rename_feature_and_check should patch top-level `name`, not `parameters`."""
+    onshape_client.get = AsyncMock(
+        return_value={"features": [_extrude_feature(feature_id="fId")]}
+    )
+    onshape_client.post = AsyncMock(
+        return_value={
+            "feature": {"featureId": "fId", "name": "Boss extrude", "featureType": "extrude"},
+            "featureState": {"featureStatus": "OK"},
+        }
+    )
+
+    result = await rename_feature_and_check(
+        onshape_client, "d", "w", "e", "fId", "Boss extrude",
+    )
+
+    assert isinstance(result, FeatureApplyResult)
+    assert result.ok is True
+    assert result.feature_name == "Boss extrude"
+
+    posted_path = onshape_client.post.await_args[0][0]
+    assert posted_path.endswith("/features/featureid/fId")
+
+    sent_payload = onshape_client.post.await_args[1]["data"]
+    assert sent_payload["feature"]["name"] == "Boss extrude"
+    # Parameters must be untouched by a rename.
+    assert sent_payload["feature"]["parameters"] == _extrude_feature(feature_id="fId")["parameters"]
+
+
+@pytest.mark.asyncio
+async def test_rename_feature_raises_for_unknown_feature(onshape_client):
+    onshape_client.get = AsyncMock(return_value={"features": []})
+    onshape_client.post = AsyncMock()
+    with pytest.raises(ValueError) as exc:
+        await rename_feature_and_check(onshape_client, "d", "w", "e", "missing", "New name")
+    assert "not found" in str(exc.value)
+    onshape_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rename_feature_rejects_missing_feature_id(onshape_client):
+    onshape_client.get = AsyncMock(return_value={"features": [_extrude_feature()]})
+    onshape_client.post = AsyncMock()
+    with pytest.raises(ValueError):
+        await rename_feature_and_check(onshape_client, "d", "w", "e", "", "New name")
+    onshape_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rename_feature_reports_post_error_status(onshape_client):
+    """A rename can still surface ERROR if the feature was already broken."""
+    onshape_client.get = AsyncMock(
+        return_value={"features": [_extrude_feature(feature_id="fId")]}
+    )
+    onshape_client.post = AsyncMock(
+        return_value={
+            "feature": {"featureId": "fId"},
+            "featureState": {"featureStatus": "ERROR", "message": "Depth must be positive"},
+        }
+    )
+
+    result = await rename_feature_and_check(onshape_client, "d", "w", "e", "fId", "New name")
+    assert result.ok is False
+    assert result.status == "ERROR"

--- a/tests/api/test_feature_apply.py
+++ b/tests/api/test_feature_apply.py
@@ -5,11 +5,13 @@ tests/real/test_feature_apply_real.py; these tests pin the
 param-merge behavior of the update helper without hitting Onshape.
 """
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
 from onshape_mcp.api.feature_apply import (
+    apply_feature_and_check,
     apply_assembly_feature_and_check,
     update_feature_params_and_check,
     rename_feature_and_check,
@@ -345,3 +347,89 @@ async def test_rename_feature_reports_post_error_status(onshape_client):
     result = await rename_feature_and_check(onshape_client, "d", "w", "e", "fId", "New name")
     assert result.ok is False
     assert result.status == "ERROR"
+
+
+class TestConcurrentWritesAreSerializedPerElement:
+    """Regression coverage for a real incident: 20 `rename_feature` calls
+    fired in parallel against one Part Studio raced on Onshape's server-side
+    base-microversion regeneration and put 21/23 features into ERROR/WARNING,
+    visibly collapsing the model (recovered via Onshape's version history).
+    apply_feature_and_check now serializes its mutating POST per
+    (document, workspace, element) so concurrent calls queue instead of
+    racing Onshape's API directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_same_element_writes_are_serialized(self, onshape_client):
+        order = []
+
+        async def fake_post(path, data=None, params=None):
+            order.append("start")
+            await asyncio.sleep(0.02)
+            order.append("end")
+            return {
+                "feature": {"featureId": "f", "name": "x", "featureType": "extrude"},
+                "featureState": {"featureStatus": "OK"},
+            }
+
+        onshape_client.post = fake_post
+
+        await asyncio.gather(
+            apply_feature_and_check(onshape_client, "d", "w", "e", {"feature": {}}),
+            apply_feature_and_check(onshape_client, "d", "w", "e", {"feature": {}}),
+        )
+
+        # Serialized: the second POST can't start until the first fully ends.
+        # A racy implementation would interleave as ["start", "start", "end", "end"].
+        assert order == ["start", "end", "start", "end"]
+
+    @pytest.mark.asyncio
+    async def test_different_elements_are_not_serialized_against_each_other(
+        self, onshape_client
+    ):
+        """The lock is per-element, not global -- unrelated Part Studios
+        must not queue behind each other."""
+        concurrent = 0
+        max_concurrent = 0
+
+        async def fake_post(path, data=None, params=None):
+            nonlocal concurrent, max_concurrent
+            concurrent += 1
+            max_concurrent = max(max_concurrent, concurrent)
+            await asyncio.sleep(0.02)
+            concurrent -= 1
+            return {
+                "feature": {"featureId": "f", "name": "x", "featureType": "extrude"},
+                "featureState": {"featureStatus": "OK"},
+            }
+
+        onshape_client.post = fake_post
+
+        await asyncio.gather(
+            apply_feature_and_check(onshape_client, "d", "w", "e1", {"feature": {}}),
+            apply_feature_and_check(onshape_client, "d", "w", "e2", {"feature": {}}),
+        )
+
+        assert max_concurrent == 2
+
+    @pytest.mark.asyncio
+    async def test_assembly_writes_are_serialized_per_element_too(self, onshape_client):
+        order = []
+
+        async def fake_post(path, data=None, params=None):
+            order.append("start")
+            await asyncio.sleep(0.02)
+            order.append("end")
+            return {
+                "feature": {"featureId": "f", "name": "x", "featureType": "mate"},
+                "featureState": {"featureStatus": "OK"},
+            }
+
+        onshape_client.post = fake_post
+
+        await asyncio.gather(
+            apply_assembly_feature_and_check(onshape_client, "d", "w", "asm", {"feature": {}}),
+            apply_assembly_feature_and_check(onshape_client, "d", "w", "asm", {"feature": {}}),
+        )
+
+        assert order == ["start", "end", "start", "end"]


### PR DESCRIPTION
## Summary

The MCP surface has no way to rename a document, an element (Part Studio/Assembly/drawing tab), or a feature in the feature tree — only create/delete. This adds the three missing rename tools.

**Update:** while dogfooding this on a real document, batch-renaming by firing 20 `rename_feature` calls in parallel corrupted the model (21/23 features went ERROR/WARNING, geometry visibly collapsed, recovered via Onshape's version history). This isn't rename-specific — it's a race in the shared `apply_feature_and_check`/`apply_assembly_feature_and_check` helpers that every mutating tool routes through — so I've included the fix in this PR rather than opening a second one for it. Details below and in the second commit.

## Changes

- `rename_document` — `POST /api/v10/documents/{did}` with `{"name": ...}`, mirroring the existing `create_document` call.
- `rename_element` — renaming a tab has no dedicated endpoint; the name lives on the element's Metadata resource. GETs current metadata, finds the property whose schema `name` is `"Name"` (rather than trusting a hardcoded `propertyId`, which looked like a metadata-schema-version detail I shouldn't assume is stable), then PATCHes just that property back.
- `rename_feature` — re-POSTs the whole feature through the same mechanism `update_feature` already uses, patching only the top-level `name` field; parameters are untouched.
- Also fixes a latent `NameError` in the existing `create_document` handler: it annotates a local as `Dict[str, Any]`, but `Dict` was never imported from `typing` (only `Any`/`Optional` were). Found this while adding `Dict`-typed code nearby; one-line fix, included since it's trivial and in the same neighborhood.
- **Concurrency fix:** `apply_feature_and_check` / `apply_assembly_feature_and_check` now serialize their mutating POST per `(document_id, workspace_id, element_id)` via an `asyncio.Lock`, keyed lazily so unrelated documents/Part Studios never queue behind each other. Root cause: Onshape's feature-tree endpoint applies each write against a base microversion and regenerates downstream features from there; concurrent mutating POSTs against the *same* Part Studio race on that base server-side and corrupt the tree, even though each individual call is a no-op on geometry in isolation. Every mutating tool (sketches, extrudes, fillets, patterns, booleans, mates, rename, update — 21 dispatch branches) goes through these two functions, so this was a live hazard for any concurrent same-element calls, not just batch renaming.

## Type of Change

- [x] Bug fix (the `Dict` import; the concurrency race)
- [x] New feature (the three rename tools)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD or build changes

## Testing

- [x] Tests pass locally (`pytest -v`) — 710 passed, no regressions
- [x] New tests added for new functionality — 12 new unit tests total: 9 across `tests/api/test_documents.py` and `tests/api/test_feature_apply.py` for the rename tools (happy path, missing-property/missing-feature error paths, error propagation), plus 3 regression tests proving same-element writes now serialize (`asyncio.gather` on two concurrent calls, asserting non-interleaved start/end order) while different elements do *not* block each other (asserting `max_concurrent == 2`).
- [ ] Coverage threshold maintained (80%+) — full-suite coverage sits at ~53% on `main` before this change too (this repo's `tests/real/` appears to need live Onshape credentials CI doesn't have), so I can't honestly claim this gate passes; it isn't something this PR changes either way. The touched files themselves are fully covered by the new/existing tests.
- [x] Additionally verified live against a real Onshape document (not just mocks) for both `rename_feature` and `rename_element` — confirmed the API round-trips the new name correctly in both cases. `rename_document` is untested live but structurally identical to the already-proven `create_document` call. The concurrency bug itself was found and the fix validated conceptually through this same live dogfooding session (the corruption was 100% reproducible with the parallel batch, pre-fix).

## Checklist

- [x] Code follows project style (`ruff check` passes clean on all 6 touched files — `onshape_mcp/api/documents.py`, `onshape_mcp/api/feature_apply.py`, `tests/api/test_documents.py`, `tests/api/test_feature_apply.py`; `onshape_mcp/server.py` has 2 pre-existing unused-import warnings unrelated to this change, left alone to keep the diff scoped)
- [x] Self-reviewed the changes
- [x] No secrets or credentials included
